### PR TITLE
Fix Plant Matter creating explosions of tall grass

### DIFF
--- a/src/main/java/com/bartz24/skyresources/base/item/BaseItemComponent.java
+++ b/src/main/java/com/bartz24/skyresources/base/item/BaseItemComponent.java
@@ -134,7 +134,9 @@ public class BaseItemComponent extends Item
 			{
 				tries--;
 				IGrowable igrowable = (IGrowable) worldIn.getBlockState(target).getBlock();
-				igrowable.grow(worldIn, worldIn.rand, target, worldIn.getBlockState(target));
+				if (igrowable.canGrow(worldIn, target, worldIn.getBlockState(target), false)) {
+					igrowable.grow(worldIn, worldIn.rand, target, worldIn.getBlockState(target));
+				}
 			}
 
 			stack.shrink(1);


### PR DESCRIPTION
Plant Matter now checks if the IGrowable can grow before growing it.

This also fixes Plant Matter creating explosions of wrong-color Tall
Mystical Flowers when used on a planted Botania flower petal.