### PR TITLE
fix block from being destroyed twice

### DIFF
--- a/src/main/java/com/bartz24/skyresources/technology/item/ItemRockGrinder.java
+++ b/src/main/java/com/bartz24/skyresources/technology/item/ItemRockGrinder.java
@@ -103,7 +103,9 @@ public class ItemRockGrinder extends ItemPickaxe
 				}
 			}
 		}
-		world.destroyBlock(pos, !worked);
+
+		if(worked && !world.isRemote)
+			world.destroyBlock(pos, !worked);
 		return worked;
 
 	}


### PR DESCRIPTION
There was a bug we can saw when destroying leave, like the breaking sound and animation was playing twice.
I think it was because when the block is destroyed server side, it was automatically resync with client so there is no need to destroy the block on client side.
Also, there is no need to destroy the block when returning false, since the block harvesting will continue as normal.