### PR TITLE
Fix #112 - RF Combustion heaters not giving enough HU/RF

### DIFF
--- a/src/main/java/com/bartz24/skyresources/technology/item/ItemCombustionHeater.java
+++ b/src/main/java/com/bartz24/skyresources/technology/item/ItemCombustionHeater.java
@@ -138,8 +138,7 @@ public class ItemCombustionHeater extends ItemMachine
 					.internalExtractEnergy((int) getMachineFuelData(machineStack, world, pos)[1], false);
 			if (extract > 0)
 			{
-				data.setFloat("itemHU", (float) (extract / (int) getMachineFuelData(machineStack, world, pos)[1])
-						/ getMachineFuelData(machineStack, world, pos)[2]);
+				data.setFloat("itemHU", extract / getMachineFuelData(machineStack, world, pos)[2]);
 				data.setFloat("huTick", getMachineFuelData(machineStack, world, pos)[0]);
 			}
 		} else if (getVariant(machineStack).getFuelType() instanceof ItemStack


### PR DESCRIPTION
The `itemHU` amount was too small due to an incorrect division. The correct figure for `itemHU` is now obtained by dividing the RF amount by the machine's "RF/HU" data (or rather, multiplying RF by HU/RF to get HU).