### PR TITLE
Fix crash when shift-clicking Catalyst into Fusion Table

### DIFF
--- a/src/main/java/com/bartz24/skyresources/alchemy/tile/TileAlchemyFusionTable.java
+++ b/src/main/java/com/bartz24/skyresources/alchemy/tile/TileAlchemyFusionTable.java
@@ -48,7 +48,7 @@ public class TileAlchemyFusionTable extends TileItemInventory implements ITickab
 						if (slot == 0 && !FusionCatalysts.isCatalyst(stack)) {
 							return stack;
 						}
-						else if (slot < 10 && !stack.isItemEqual(TileAlchemyFusionTable.this.filter.get(slot - 1)))
+						if (slot > 0 && slot < 10 && !stack.isItemEqual(TileAlchemyFusionTable.this.filter.get(slot - 1)))
 							return stack;
 						return super.insertItem(slot, stack, simulate);
 					}


### PR DESCRIPTION
Crash looks like [`java.lang.ArrayIndexOutOfBoundsException: -1`](https://gist.github.com/codewarrior0/3151f847ad6aa0d7848b375aac41fbcf)